### PR TITLE
Changed gap.gap_to_tir function, incremented to 0.1.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     name='pybis',
 
 # PEP - version as three components ("major.minor.micro")
-    version='0.1.3',
+    version='0.1.4',
 
     description='A set of helper code for Biogeographic Information System projects',
     long_description=read('README.rst'),


### PR DESCRIPTION
Changed the gap_to_tir function significantly to build a GAP species data structure using the item model created in ScienceBase. Key information elements there are the identifiers and files constructs. Identifiers are processed to pull out a usable ITIS TSN. The TSN is given a qualifier based on type assignment on the item and pulling descriptive information for the qualifier from the ScienceBase Vocabulary (kind of clunky for now). I also used TSN to go after information on the FWS ESA listing status using TESS.

In addition to the identifiers, I also grabbed up and included the species model report that is included as a JSON document attached to each species item.

This function takes advantage of the previously created ITIS and TESS components of the Taxa Information Registry codebase.

The intent of this is to run through the species items in ScienceBase and cache out TIR information for them to be used in applications via a new method in the bis-api (to be developed).